### PR TITLE
Assorted changes to builder + build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Fioxa
+
+## Building
+
+Ensure that you have `qemu` and `ovmf` installed on your linux computer. In `builder/`, run `cargo run qemu`.

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.71"
 cargo_metadata = "0.14"
+thiserror = "1.0.24"

--- a/builder/src/errors.rs
+++ b/builder/src/errors.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum BuildErrors {
+    #[error("cargo did not output anything to stdout")]
+    NoOutput,
+    #[error("could not find executable")]
+    MissingExec,
+    #[error("build failed")]
+    BuildFailed,
+    #[error("build did not complete")]
+    Incomplete,
+}
+
+#[derive(Debug, Error)]
+pub enum QEMUErrors {
+    #[error("It looks like you don't have KVM enabled. System OVFM only seems to work with KVM enabled. If you think you know what you are doing, comment out this error code & rebuild.")]
+    MissingKVM,
+}

--- a/builder/src/errors.rs
+++ b/builder/src/errors.rs
@@ -16,4 +16,6 @@ pub enum BuildErrors {
 pub enum QEMUErrors {
     #[error("It looks like you don't have KVM enabled. System OVFM only seems to work with KVM enabled. If you think you know what you are doing, comment out this error code & rebuild.")]
     MissingKVM,
+    #[error("Could not find local OVMF or system OVMF!")]
+    NoOVMF,
 }

--- a/builder/src/main.rs
+++ b/builder/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(string_leak)]
-
 use std::{
     env::args,
     fs::{copy, DirBuilder},
@@ -55,15 +53,23 @@ fn main() -> Result<()> {
 fn qemu() -> Result<()> {
     let mut qemu_args = vec![
         // GDB server
-        "-s", "-S", // Args
-        "-machine", "q35", // "-no-shutdown",
+        "-s".to_string(),
+        "-S".to_string(), // Args
+        "-machine".to_string(),
+        "q35".to_string(), // "-no-shutdown",
         // "-no-reboot",
-        "-cpu", "qemu64", "-smp", // "cores=12",
-        "cores=4", "-m", "512M", "-serial", "stdio",
+        "-cpu".to_string(),
+        "qemu64".to_string(),
+        "-smp".to_string(), // "cores=12",
+        "cores=4".to_string(),
+        "-m".to_string(),
+        "512M".to_string(),
+        "-serial".to_string(),
+        "stdio".to_string(),
     ];
 
     if has_kvm() {
-        qemu_args.push("-enable-kvm");
+        qemu_args.push("-enable-kvm".to_string());
     }
 
     let pure_path = Path::new(PURE_EFI_PATH);
@@ -74,8 +80,8 @@ fn qemu() -> Result<()> {
     if pure_path.exists() {
         println!("Using local OVFM");
 
-        qemu_args.push("-drive");
-        qemu_args.push(format!("if=pflash,format=raw,file={}", PURE_EFI_PATH).leak());
+        qemu_args.push("-drive".to_string());
+        qemu_args.push(format!("if=pflash,format=raw,file={}", PURE_EFI_PATH));
     } else if system_code.exists() && system_vars.exists() {
         println!("Using system OVFM");
 
@@ -92,20 +98,23 @@ fn qemu() -> Result<()> {
             return Err(QEMUErrors::MissingKVM.into());
         }
 
-        qemu_args.push("-drive");
-        qemu_args.push(format!("if=pflash,format=raw,readonly=on,file={}", SYSTEM_EFI_CODE).leak());
+        qemu_args.push("-drive".to_string());
+        qemu_args.push(format!(
+            "if=pflash,format=raw,readonly=on,file={}",
+            SYSTEM_EFI_CODE
+        ));
 
-        qemu_args.push("-drive");
-        qemu_args.push("if=pflash,format=raw,file=ovmf/VARS.fd");
+        qemu_args.push("-drive".to_string());
+        qemu_args.push("if=pflash,format=raw,file=ovmf/VARS.fd".to_string());
     } else {
-        panic!("Could not find local OVMF or system OVMF!");
+        return Err(QEMUErrors::NoOVMF.into());
     }
 
     qemu_args.append(&mut vec![
-        "-drive",
-        "format=raw,file=fat:rw:fioxa",
-        "-drive",
-        "format=raw,file=fat:rw:src",
+        "-drive".to_string(),
+        "format=raw,file=fat:rw:fioxa".to_string(),
+        "-drive".to_string(),
+        "format=raw,file=fat:rw:src".to_string(),
     ]);
 
     Command::new("qemu-system-x86_64")

--- a/builder/src/main.rs
+++ b/builder/src/main.rs
@@ -166,7 +166,7 @@ fn has_kvm() -> bool {
     Path::new("/dev/kvm").exists()
 }
 
-#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[cfg(not(target_os = "linux"))]
 fn has_kvm() -> bool {
     // QEMU does not have KVM support on windows
     false


### PR DESCRIPTION
Primarily:
- Builder can now use system OVMF files
- Slightly less boilerplate when adding a new binary to build
- More detailed errors