### PR TITLE
flake: update and remove nightly date pin

### DIFF
--- a/apps/.cargo/config.toml
+++ b/apps/.cargo/config.toml
@@ -1,6 +1,7 @@
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
 build-std-features = ["compiler-builtins-mem"]
+json-target-spec = true
 
 [build]
 target = "x86_64-unknown-fioxa.json"

--- a/apps/calc/src/main.rs
+++ b/apps/calc/src/main.rs
@@ -121,7 +121,7 @@ pub fn main() {
         }
     } else {
         print!("{args} ");
-        match solve(&args) {
+        match solve(args) {
             Ok(sol) => println!(" = {sol}"),
             Err(e) => println!(" {e}"),
         }

--- a/drivers/.cargo/config.toml
+++ b/drivers/.cargo/config.toml
@@ -1,6 +1,7 @@
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
 build-std-features = ["compiler-builtins-mem"]
+json-target-spec = true
 
 [build]
 target = "x86_64-unknown-fioxa.json"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769092226,
-        "narHash": "sha256-6h5sROT/3CTHvzPy9koKBmoCa2eJKh4fzQK8eYFEgl8=",
+        "lastModified": 1775064974,
+        "narHash": "sha256-fp7+8MzxHrIixIIVvyORI2XpqpQnxf8NodmEHy8rczg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b579d443b37c9c5373044201ea77604e37e748c8",
+        "rev": "6ebfbc38bdc6b22822a6f991f2d922306f33cfbc",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769222645,
-        "narHash": "sha256-gu6oZ86zLudBZMq8LL1qdtYt/S69GV5keQVXdvBrVSU=",
+        "lastModified": 1775099554,
+        "narHash": "sha256-3xBsGnGDLOFtnPZ1D3j2LU19wpAlYefRKTlkv648rU0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "22da29e7f3d8cff75009cbbcf992c7cb66920cfd",
+        "rev": "8d6387ed6d8e6e6672fd3ed4b61b59d44b124d99",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
             pkgs.qemu_kvm
           ];
           buildInputs = [
-            (pkgs.rust-bin.nightly."2026-01-23".default.override {
+            (pkgs.rust-bin.nightly.latest.default.override {
               extensions = [
                 "rustc"
                 "cargo"

--- a/kernel/.cargo/config.toml
+++ b/kernel/.cargo/config.toml
@@ -1,6 +1,7 @@
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
 build-std-features = ["compiler-builtins-mem"]
+json-target-spec = true
 
 [build]
 target = "x86_64-unknown-fioxa.json"

--- a/libs/kernel_userspace/src/lib.rs
+++ b/libs/kernel_userspace/src/lib.rs
@@ -1,7 +1,4 @@
 #![no_std]
-#![feature(fn_traits)]
-#![feature(box_into_inner)]
-#![feature(try_trait_v2)]
 
 #[macro_use]
 extern crate alloc;


### PR DESCRIPTION
Removes the date pin, so that updating rust (and the entire build system under nix) is completed by a simple `nix flake update`.